### PR TITLE
[FEATURE] Edge 역방향 TTS 재생 경로 구현

### DIFF
--- a/src/edge/alerts.py
+++ b/src/edge/alerts.py
@@ -1,12 +1,25 @@
 import logging
+import shlex
+import shutil
+import subprocess
 import time
 
 
 class AlertController:
-    def __init__(self, led_pin: int, simulate_only: bool = True) -> None:
+    def __init__(
+        self,
+        led_pin: int,
+        simulate_only: bool = True,
+        tts_enabled: bool = True,
+        tts_command: str | None = None,
+        tts_timeout_sec: int = 8,
+    ) -> None:
         self.simulate_only = simulate_only
+        self.tts_enabled = tts_enabled
+        self.tts_timeout_sec = tts_timeout_sec
         self.logger = logging.getLogger(__name__)
         self._led = None
+        self._tts_cmd = self._resolve_tts_command(tts_command)
 
         if self.simulate_only:
             self.logger.info("Alert controller in simulate mode.")
@@ -19,6 +32,23 @@ class AlertController:
         except Exception as exc:
             self.logger.warning("GPIO LED init failed. Fallback to simulate mode: %s", exc)
             self.simulate_only = True
+
+    def _resolve_tts_command(self, tts_command: str | None) -> list[str] | None:
+        if not self.tts_enabled:
+            return None
+
+        if tts_command:
+            tokens = shlex.split(tts_command)
+            if tokens and shutil.which(tokens[0]):
+                return tokens
+            self.logger.warning("Configured TTS command unavailable: %s", tts_command)
+            return None
+
+        for candidate in ("espeak-ng", "espeak", "spd-say", "say"):
+            if shutil.which(candidate):
+                return [candidate]
+        self.logger.warning("No local TTS binary found. Tried espeak-ng/espeak/spd-say/say.")
+        return None
 
     def trigger_danger(self, duration_sec: int = 3) -> None:
         self.logger.warning("Danger alert triggered for %ss", duration_sec)
@@ -35,7 +65,35 @@ class AlertController:
         if self._led is not None:
             self._led.off()
 
+    def speak(self, text: str) -> None:
+        if not self.tts_enabled:
+            return
+
+        text = text.strip()
+        if not text:
+            return
+
+        if self.simulate_only:
+            self.logger.warning("[SIM] TTS: %s", text)
+            return
+
+        if not self._tts_cmd:
+            self.logger.warning("TTS skipped: command not configured or unavailable.")
+            return
+
+        try:
+            completed = subprocess.run(
+                [*self._tts_cmd, text],
+                timeout=self.tts_timeout_sec,
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if completed.returncode != 0:
+                self.logger.warning("TTS command returned non-zero code=%s", completed.returncode)
+        except Exception as exc:
+            self.logger.warning("TTS playback failed: %s", exc)
+
     def cleanup(self) -> None:
         if self._led is not None:
             self._led.off()
-

--- a/src/edge/config.py
+++ b/src/edge/config.py
@@ -15,6 +15,10 @@ class EdgeConfig:
     alert_duration_sec: int = 3
     led_gpio_pin: int = 17
     simulate_alert_only: bool = True
+    tts_enabled: bool = True
+    tts_command: str | None = None
+    tts_timeout_sec: int = 8
+    tts_use_event_summary_fallback: bool = True
     log_level: str = "INFO"
 
     @classmethod
@@ -31,6 +35,9 @@ class EdgeConfig:
             alert_duration_sec=int(os.getenv("EDGE_ALERT_DURATION_SEC", "3")),
             led_gpio_pin=int(os.getenv("EDGE_LED_GPIO_PIN", "17")),
             simulate_alert_only=os.getenv("EDGE_SIMULATE_ALERT_ONLY", "true").lower() == "true",
+            tts_enabled=os.getenv("EDGE_TTS_ENABLED", "true").lower() == "true",
+            tts_command=(os.getenv("EDGE_TTS_COMMAND") or "").strip() or None,
+            tts_timeout_sec=int(os.getenv("EDGE_TTS_TIMEOUT_SEC", "8")),
+            tts_use_event_summary_fallback=os.getenv("EDGE_TTS_EVENT_SUMMARY_FALLBACK", "true").lower() == "true",
             log_level=os.getenv("EDGE_LOG_LEVEL", "INFO").upper(),
         )
-

--- a/src/edge/server_client.py
+++ b/src/edge/server_client.py
@@ -3,6 +3,9 @@ import time
 from typing import Any
 
 import requests
+from pydantic import ValidationError
+
+from src.api.models import DangerEventAck
 
 
 class DangerEventClient:
@@ -14,7 +17,7 @@ class DangerEventClient:
         self.logger = logging.getLogger(__name__)
         self.session = requests.Session()
 
-    def send(self, payload: dict[str, Any]) -> bool:
+    def send(self, payload: dict[str, Any]) -> dict[str, Any] | None:
         url = f"{self.base_url}{self.endpoint}"
         last_error = None
 
@@ -23,7 +26,7 @@ class DangerEventClient:
                 response = self.session.post(url, json=payload, timeout=self.timeout_sec)
                 if response.ok:
                     self.logger.info("Danger event sent: status=%s event_id=%s", response.status_code, payload["event_id"])
-                    return True
+                    return self._parse_ack(response)
                 last_error = RuntimeError(f"status={response.status_code} body={response.text[:200]}")
             except Exception as exc:
                 last_error = exc
@@ -32,5 +35,24 @@ class DangerEventClient:
             time.sleep(0.4)
 
         self.logger.error("Danger event send failed after retries: %s", last_error)
-        return False
+        return None
 
+    def _parse_ack(self, response: requests.Response) -> dict[str, Any]:
+        content_type = response.headers.get("content-type", "")
+        if "application/json" not in content_type.lower():
+            return {}
+        try:
+            validated = DangerEventAck.model_validate_json(response.text)
+            return validated.model_dump(mode="json")
+        except ValidationError as exc:
+            self.logger.warning("Ack schema validation failed. Fallback to raw JSON parse: %s", exc)
+        except Exception:
+            self.logger.warning("Failed to decode JSON ack body from server.")
+
+        try:
+            body = response.json()
+            if isinstance(body, dict):
+                return body
+        except Exception:
+            self.logger.warning("Fallback raw JSON parse failed.")
+        return {}


### PR DESCRIPTION
## 연관 이슈
- closes #12

## 변경 요약
- Edge가 `/events/danger` ACK에서 `jetson_tts_summary`를 수신/검증
- Edge 로컬 TTS 재생 경로 연결
- 응답 누락/전송 실패 fallback 동작 추가