### PR TITLE
[FEATURE] MCP 서버 분리 및 Ops Discord 전환

### DIFF
--- a/src/api/config.py
+++ b/src/api/config.py
@@ -36,21 +36,43 @@ class ApiConfig:
     rag_mcp_path: str = "/mcp"
     rag_mcp_autostart: bool = True
 
+    ops_mcp_enabled: bool = True
+    ops_mcp_timeout_sec: float = 8.0
+    ops_mcp_discord_enabled: bool = True
+    ops_mcp_discord_tool_name: str = "discord_send_alert"
+    ops_mcp_transport: str = "streamable_http"
+    ops_mcp_command: str = "python3"
+    ops_mcp_args: list[str] | None = None
+    ops_mcp_url: str | None = None
+    ops_mcp_host: str = "127.0.0.1"
+    ops_mcp_port: int = 8766
+    ops_mcp_path: str = "/mcp"
+
     llm_provider: str = "gemini"
     gemini_model: str = "gemini-3-flash-preview"
     google_api_key: str | None = None
 
     @classmethod
     def from_env(cls) -> "ApiConfig":
-        args_str = os.getenv("RAG_MCP_ARGS", "-m src.mcp.rag_server")
-        mcp_host = os.getenv("RAG_MCP_HOST", "127.0.0.1")
-        mcp_port = int(os.getenv("RAG_MCP_PORT", "8765"))
-        mcp_path = os.getenv("RAG_MCP_PATH", "/mcp")
-        mcp_transport = os.getenv("RAG_MCP_TRANSPORT", "streamable_http")
-        mcp_url = os.getenv("RAG_MCP_URL")
-        if not mcp_url and mcp_transport == "streamable_http":
-            normalized_path = mcp_path if mcp_path.startswith("/") else f"/{mcp_path}"
-            mcp_url = f"http://{mcp_host}:{mcp_port}{normalized_path}"
+        rag_args_str = os.getenv("RAG_MCP_ARGS", "-m src.mcp.rag_server")
+        rag_mcp_host = os.getenv("RAG_MCP_HOST", "127.0.0.1")
+        rag_mcp_port = int(os.getenv("RAG_MCP_PORT", "8765"))
+        rag_mcp_path = os.getenv("RAG_MCP_PATH", "/mcp")
+        rag_mcp_transport = os.getenv("RAG_MCP_TRANSPORT", "streamable_http")
+        rag_mcp_url = os.getenv("RAG_MCP_URL")
+        if not rag_mcp_url and rag_mcp_transport == "streamable_http":
+            normalized_path = rag_mcp_path if rag_mcp_path.startswith("/") else f"/{rag_mcp_path}"
+            rag_mcp_url = f"http://{rag_mcp_host}:{rag_mcp_port}{normalized_path}"
+
+        ops_args_str = os.getenv("OPS_MCP_ARGS", "-m src.mcp.ops_server")
+        ops_mcp_host = os.getenv("OPS_MCP_HOST", "127.0.0.1")
+        ops_mcp_port = int(os.getenv("OPS_MCP_PORT", "8766"))
+        ops_mcp_path = os.getenv("OPS_MCP_PATH", "/mcp")
+        ops_mcp_transport = os.getenv("OPS_MCP_TRANSPORT", "streamable_http")
+        ops_mcp_url = os.getenv("OPS_MCP_URL")
+        if not ops_mcp_url and ops_mcp_transport == "streamable_http":
+            normalized_path = ops_mcp_path if ops_mcp_path.startswith("/") else f"/{ops_mcp_path}"
+            ops_mcp_url = f"http://{ops_mcp_host}:{ops_mcp_port}{normalized_path}"
 
         return cls(
             host=os.getenv("API_HOST", "0.0.0.0"),
@@ -64,14 +86,25 @@ class ApiConfig:
             rag_mcp_tool_name=os.getenv("RAG_MCP_TOOL_NAME", "retrieve_guidelines"),
             rag_mcp_query_key=os.getenv("RAG_MCP_QUERY_KEY", "query"),
             rag_mcp_top_k_key=os.getenv("RAG_MCP_TOP_K_KEY", "top_k"),
-            rag_mcp_transport=mcp_transport,
+            rag_mcp_transport=rag_mcp_transport,
             rag_mcp_command=os.getenv("RAG_MCP_COMMAND", sys.executable),
-            rag_mcp_args=shlex.split(args_str) if args_str else None,
-            rag_mcp_url=mcp_url,
-            rag_mcp_host=mcp_host,
-            rag_mcp_port=mcp_port,
-            rag_mcp_path=mcp_path,
+            rag_mcp_args=shlex.split(rag_args_str) if rag_args_str else None,
+            rag_mcp_url=rag_mcp_url,
+            rag_mcp_host=rag_mcp_host,
+            rag_mcp_port=rag_mcp_port,
+            rag_mcp_path=rag_mcp_path,
             rag_mcp_autostart=os.getenv("RAG_MCP_AUTOSTART", "true").lower() == "true",
+            ops_mcp_enabled=os.getenv("OPS_MCP_ENABLED", "true").lower() == "true",
+            ops_mcp_timeout_sec=float(os.getenv("OPS_MCP_TIMEOUT_SEC", "8.0")),
+            ops_mcp_discord_enabled=os.getenv("OPS_MCP_DISCORD_ENABLED", "true").lower() == "true",
+            ops_mcp_discord_tool_name=os.getenv("OPS_MCP_DISCORD_TOOL_NAME", "discord_send_alert"),
+            ops_mcp_transport=ops_mcp_transport,
+            ops_mcp_command=os.getenv("OPS_MCP_COMMAND", sys.executable),
+            ops_mcp_args=shlex.split(ops_args_str) if ops_args_str else None,
+            ops_mcp_url=ops_mcp_url,
+            ops_mcp_host=ops_mcp_host,
+            ops_mcp_port=ops_mcp_port,
+            ops_mcp_path=ops_mcp_path,
             llm_provider=os.getenv("LLM_PROVIDER", "gemini"),
             gemini_model=os.getenv("GEMINI_MODEL", "gemini-3-flash-preview"),
             google_api_key=os.getenv("GOOGLE_API_KEY"),

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -10,11 +11,13 @@ from src.api.config import ApiConfig
 from src.api.models import DangerEvent, DangerEventAck, DangerResponse
 from src.api.services.llm_responder import LLMResponder
 from src.api.services.local_rag import LocalRAGRetriever
+from src.api.services.mcp_ops import MCPOperationsPublisher
 from src.api.services.mcp_rag import MCPRAGRetriever
 from src.api.services.pipeline import DangerProcessingPipeline
 
 CONFIG = ApiConfig.from_env()
 app = FastAPI(title="SentinelHybrid Danger Event API", version="0.2.0")
+LOGGER = logging.getLogger(__name__)
 
 EVENT_LOG_PATH = Path(CONFIG.event_log_path)
 RESPONSE_LOG_PATH = Path(CONFIG.response_log_path)
@@ -30,6 +33,7 @@ PIPELINE = DangerProcessingPipeline(
     responder=LLMResponder(CONFIG),
     mcp_timeout_sec=CONFIG.rag_mcp_timeout_sec,
 )
+OPS_PUBLISHER = MCPOperationsPublisher(CONFIG)
 
 if ADMIN_DIR.exists():
     app.mount("/admin/static", StaticFiles(directory=str(ADMIN_DIR)), name="admin-static")
@@ -98,6 +102,8 @@ async def receive_danger_event(event: DangerEvent) -> DangerEventAck:
         return DangerEventAck(status="ignored_non_danger", event_id=event.event_id)
 
     response: DangerResponse = await PIPELINE.process(event)
+    ops_result = await OPS_PUBLISHER.publish(event=event, response=response)
+    LOGGER.info("MCP ops publish result. event_id=%s result=%s", event.event_id, ops_result)
     response_payload = response.model_dump(mode="json")
     _append_jsonl(RESPONSE_LOG_PATH, response_payload)
     _push_recent(RECENT_RESPONSES, response_payload)

--- a/src/api/services/mcp_ops.py
+++ b/src/api/services/mcp_ops.py
@@ -1,0 +1,138 @@
+import asyncio
+import json
+import logging
+from typing import Any
+
+from src.api.config import ApiConfig
+from src.api.models import DangerEvent, DangerResponse
+
+
+class MCPOperationsPublisher:
+    def __init__(self, config: ApiConfig) -> None:
+        self.config = config
+        self.logger = logging.getLogger(__name__)
+        self._client = None
+        self._tools: dict[str, Any] = {}
+        self._tool_lock = asyncio.Lock()
+
+    async def _get_tool(self, tool_name: str):
+        if tool_name in self._tools:
+            return self._tools[tool_name]
+
+        try:
+            from langchain_mcp_adapters.client import MultiServerMCPClient
+        except Exception as exc:  # pragma: no cover
+            self.logger.warning("langchain-mcp-adapters unavailable for ops publish: %s", exc)
+            return None
+
+        async with self._tool_lock:
+            if tool_name in self._tools:
+                return self._tools[tool_name]
+
+            if self._client is None:
+                if self.config.ops_mcp_transport == "streamable_http" and self.config.ops_mcp_url:
+                    server_cfg = {
+                        "transport": "streamable_http",
+                        "url": self.config.ops_mcp_url,
+                    }
+                else:
+                    server_cfg = {
+                        "transport": "stdio",
+                        "command": self.config.ops_mcp_command,
+                        "args": self.config.ops_mcp_args or ["-m", "src.mcp.ops_server"],
+                    }
+                try:
+                    self._client = MultiServerMCPClient({"ops": server_cfg})
+                except Exception as exc:
+                    self.logger.warning("MCP ops client init failed: %s", exc)
+                    self._client = None
+                    return None
+
+            try:
+                tools = await self._client.get_tools()
+                for tool in tools:
+                    self._tools[tool.name] = tool
+                selected = self._tools.get(tool_name)
+                if selected is None:
+                    self.logger.warning("MCP ops tool not found: %s", tool_name)
+                return selected
+            except Exception as exc:
+                self.logger.warning("MCP ops tool discovery failed: %s", exc)
+                self._tools = {}
+                return None
+
+    async def _invoke(self, tool_name: str, payload: dict[str, Any]) -> dict[str, Any]:
+        tool = await self._get_tool(tool_name)
+        if tool is None:
+            return {"status": "tool-unavailable", "tool": tool_name}
+
+        try:
+            raw = await asyncio.wait_for(
+                tool.ainvoke(payload),
+                timeout=self.config.ops_mcp_timeout_sec,
+            )
+            normalized = self._normalize(raw)
+            if isinstance(normalized, dict):
+                return normalized
+            return {"status": "ok", "result": normalized}
+        except Exception as exc:
+            self.logger.warning("MCP ops invoke failed. tool=%s err=%s", tool_name, exc)
+            return {"status": "error", "tool": tool_name, "error": str(exc)}
+
+    def _normalize(self, raw: Any) -> Any:
+        if isinstance(raw, list):
+            for item in raw:
+                if isinstance(item, dict) and isinstance(item.get("text"), str):
+                    text = item["text"].strip()
+                    try:
+                        return json.loads(text)
+                    except Exception:
+                        return {"status": "ok", "message": text}
+            return {"status": "ok"}
+
+        if isinstance(raw, str):
+            try:
+                return json.loads(raw)
+            except Exception:
+                return {"status": "ok", "message": raw}
+
+        if isinstance(raw, dict):
+            return raw
+
+        return {"status": "ok", "result": str(raw)}
+
+    def _discord_text(self, event: DangerEvent, response: DangerResponse) -> str:
+        return (
+            "[SentinelHybrid] 위험 이벤트 감지\n"
+            f"- event_id: {event.event_id}\n"
+            f"- source: {event.source}\n"
+            f"- summary: {event.summary}\n"
+            f"- rag_source: {response.rag_source}\n"
+            f"- tts: {response.jetson_tts_summary}"
+        )
+
+    async def publish(self, event: DangerEvent, response: DangerResponse) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if not self.config.ops_mcp_enabled:
+            return {"status": "disabled"}
+
+        jobs: list[tuple[str, Any]] = []
+        if self.config.ops_mcp_discord_enabled:
+            payload = {
+                "text": self._discord_text(event, response),
+                "event_id": event.event_id,
+                "severity": "danger",
+            }
+            jobs.append(("discord", self._invoke(self.config.ops_mcp_discord_tool_name, payload)))
+        else:
+            result["discord"] = {"status": "disabled"}
+
+        if jobs:
+            outputs = await asyncio.gather(*(job for _, job in jobs), return_exceptions=True)
+            for (channel, _), output in zip(jobs, outputs):
+                if isinstance(output, Exception):
+                    result[channel] = {"status": "error", "error": str(output)}
+                    continue
+                result[channel] = output
+
+        return result

--- a/src/mcp/ops_server.py
+++ b/src/mcp/ops_server.py
@@ -1,0 +1,86 @@
+import os
+
+from pydantic import BaseModel, Field, ValidationError
+
+try:
+    from fastmcp import FastMCP
+except ImportError as exc:  # pragma: no cover
+    raise RuntimeError("fastmcp is required to run the MCP Ops server.") from exc
+
+mcp = FastMCP("SentinelHybridOps")
+
+DISCORD_WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL", "")
+DISCORD_TIMEOUT_SEC = float(os.getenv("DISCORD_TIMEOUT_SEC", "6"))
+
+
+class DiscordAlertInput(BaseModel):
+    text: str = Field(min_length=1, max_length=4000)
+    event_id: str = ""
+    severity: str = "danger"
+
+
+class ToolResult(BaseModel):
+    status: str
+    reason: str | None = None
+    http_status: int | None = None
+    body: str | None = None
+    error: str | None = None
+
+
+@mcp.tool
+def discord_send_alert(text: str, event_id: str = "", severity: str = "danger") -> dict:
+    try:
+        req = DiscordAlertInput.model_validate(
+            {
+                "text": text,
+                "event_id": event_id,
+                "severity": severity,
+            }
+        )
+    except ValidationError as exc:
+        return ToolResult(status="error", reason=f"invalid discord alert input: {exc}").model_dump(mode="json")
+
+    if not DISCORD_WEBHOOK_URL:
+        return ToolResult(status="skipped", reason="DISCORD_WEBHOOK_URL is not configured").model_dump(mode="json")
+
+    try:
+        import requests
+    except Exception as exc:
+        return ToolResult(status="error", reason=f"requests import failed: {exc}").model_dump(mode="json")
+
+    payload = {"text": req.text}
+    if req.event_id:
+        payload["text"] = f"{req.text}\n(event_id={req.event_id}, severity={req.severity})"
+
+    try:
+        response = requests.post(
+            DISCORD_WEBHOOK_URL,
+            json=payload,
+            timeout=DISCORD_TIMEOUT_SEC,
+        )
+        if response.ok:
+            return ToolResult(status="ok", http_status=response.status_code).model_dump(mode="json")
+        return ToolResult(
+            status="error",
+            http_status=response.status_code,
+            body=response.text[:300],
+        ).model_dump(mode="json")
+    except Exception as exc:
+        return ToolResult(status="error", error=str(exc)).model_dump(mode="json")
+
+
+if __name__ == "__main__":
+    transport = os.getenv("OPS_SERVER_MCP_TRANSPORT", os.getenv("SENTINEL_MCP_TRANSPORT", "stdio"))
+    if transport == "streamable-http":
+        host = os.getenv("OPS_SERVER_MCP_HOST", os.getenv("SENTINEL_MCP_HOST", "127.0.0.1"))
+        port = int(os.getenv("OPS_SERVER_MCP_PORT", os.getenv("SENTINEL_MCP_PORT", "8766")))
+        path = os.getenv("OPS_SERVER_MCP_PATH", os.getenv("SENTINEL_MCP_PATH", "/mcp"))
+        mcp.run(
+            transport="streamable-http",
+            host=host,
+            port=port,
+            path=path,
+            show_banner=False,
+        )
+    else:
+        mcp.run(transport="stdio", show_banner=False)

--- a/src/mcp/rag_server.py
+++ b/src/mcp/rag_server.py
@@ -135,11 +135,11 @@ def retrieve_guidelines(query: str, top_k: int = 3) -> dict:
 
 
 if __name__ == "__main__":
-    transport = os.getenv("SENTINEL_MCP_TRANSPORT", "stdio")
+    transport = os.getenv("RAG_SERVER_MCP_TRANSPORT", os.getenv("SENTINEL_MCP_TRANSPORT", "stdio"))
     if transport == "streamable-http":
-        host = os.getenv("SENTINEL_MCP_HOST", "127.0.0.1")
-        port = int(os.getenv("SENTINEL_MCP_PORT", "8765"))
-        path = os.getenv("SENTINEL_MCP_PATH", "/mcp")
+        host = os.getenv("RAG_SERVER_MCP_HOST", os.getenv("SENTINEL_MCP_HOST", "127.0.0.1"))
+        port = int(os.getenv("RAG_SERVER_MCP_PORT", os.getenv("SENTINEL_MCP_PORT", "8765")))
+        path = os.getenv("RAG_SERVER_MCP_PATH", os.getenv("SENTINEL_MCP_PATH", "/mcp"))
         mcp.run(
             transport="streamable-http",
             host=host,


### PR DESCRIPTION
## 연관 이슈
- closes #13

## 변경 요약
- RAG/OPS MCP 서버 책임 분리
- Ops를 Discord 단일 채널로 전환
- Supabase/Slack ops 경로 제거