### PR TITLE
[ENHANCEMENT] API Pipeline Hazard 로직 분리 및 타입 강화 (7차)

### DIFF
--- a/src/api/services/hazard_context.py
+++ b/src/api/services/hazard_context.py
@@ -1,0 +1,77 @@
+from typing import Literal, cast
+
+from src.api.models import DangerEvent, RAGReference
+
+HazardHint = Literal["fire", "fall", "intrusion", "electrical", "general"]
+
+
+class HazardContextService:
+    HAZARD_KEYWORDS: dict[str, tuple[str, ...]] = {
+        "fire": ("화재", "연기", "불꽃", "가열", "과열"),
+        "fall": ("낙상", "전도", "미끄", "넘어"),
+        "intrusion": ("무단", "침입", "위협", "폭력", "이상행동", "비인가"),
+        "electrical": ("전기", "누전", "합선", "스파크", "감전"),
+    }
+
+    HAZARD_LABELS: dict[str, str] = {
+        "fire": "화재/연기",
+        "fall": "전도/낙상",
+        "intrusion": "무단 접근/위험 행동",
+        "electrical": "전기 설비 이상",
+        "general": "일반 위험",
+    }
+
+    def infer_hazard_hint(self, event: DangerEvent) -> HazardHint:
+        meta = event.metadata if isinstance(event.metadata, dict) else {}
+        scenario = str(meta.get("scenario", "")).strip().lower()
+        if scenario in {"fire", "fall", "intrusion", "electrical"}:
+            return cast(HazardHint, scenario)
+
+        summary = event.summary.lower()
+        for hazard, keywords in self.HAZARD_KEYWORDS.items():
+            if any(keyword in summary for keyword in keywords):
+                return cast(HazardHint, hazard)
+        return "general"
+
+    def build_rag_query(self, summary: str, hazard_hint: HazardHint) -> str:
+        if hazard_hint == "general":
+            return summary
+        hazard_label = self.HAZARD_LABELS.get(hazard_hint, "일반 위험")
+        return f"{hazard_label} 대응 기준으로 검색: {summary}"
+
+    def _score_reference(self, reference: RAGReference, hazard_hint: HazardHint) -> int:
+        if hazard_hint == "general":
+            return 0
+        joined = " ".join(
+            [reference.title, reference.content, " ".join(reference.tags)]
+        ).lower()
+        keywords = self.HAZARD_KEYWORDS.get(hazard_hint, ())
+        return sum(1 for keyword in keywords if keyword in joined)
+
+    def rerank_references(
+        self,
+        references: list[RAGReference],
+        hazard_hint: HazardHint,
+        top_k: int,
+    ) -> list[RAGReference]:
+        if not references or hazard_hint == "general":
+            return references
+
+        positives: list[tuple[int, RAGReference]] = []
+        generals: list[RAGReference] = []
+        for ref in references:
+            score = self._score_reference(ref, hazard_hint)
+            if score > 0:
+                positives.append((score, ref))
+            elif ref.id.startswith("general") or "공통" in ref.title:
+                generals.append(ref)
+
+        if not positives:
+            return references
+
+        positives.sort(key=lambda item: item[0], reverse=True)
+        ranked = [ref for _, ref in positives]
+        if generals:
+            ranked.append(generals[0])
+
+        return ranked[:top_k] if top_k > 0 else ranked

--- a/src/api/services/pipeline.py
+++ b/src/api/services/pipeline.py
@@ -1,105 +1,66 @@
 import asyncio
 
-from src.api.models import DangerEvent, DangerResponse
+from src.api.models import DangerEvent, DangerResponse, RAGReference
 from src.api.services.gemini_tts import GeminiTTSGenerator
+from src.api.services.hazard_context import HazardContextService, HazardHint
 from src.api.services.llm_responder import LLMResponder
 from src.api.services.local_rag import LocalRAGRetriever
 from src.api.services.mcp_rag import MCPRAGRetriever
 
 
 class DangerProcessingPipeline:
-    HAZARD_KEYWORDS: dict[str, tuple[str, ...]] = {
-        "fire": ("화재", "연기", "불꽃", "가열", "과열"),
-        "fall": ("낙상", "전도", "미끄", "넘어"),
-        "intrusion": ("무단", "침입", "위협", "폭력", "이상행동", "비인가"),
-        "electrical": ("전기", "누전", "합선", "스파크", "감전"),
-    }
-
     def __init__(
         self,
         mcp_retriever: MCPRAGRetriever,
         local_retriever: LocalRAGRetriever,
         responder: LLMResponder,
         tts_generator: GeminiTTSGenerator,
+        hazard_context: HazardContextService | None = None,
         mcp_timeout_sec: float = 2.0,
     ) -> None:
         self.mcp_retriever = mcp_retriever
         self.local_retriever = local_retriever
         self.responder = responder
         self.tts_generator = tts_generator
+        self.hazard_context = hazard_context or HazardContextService()
         self.mcp_timeout_sec = mcp_timeout_sec
 
-    def _infer_hazard_hint(self, event: DangerEvent) -> str:
-        meta = event.metadata if isinstance(event.metadata, dict) else {}
-        scenario = str(meta.get("scenario", "")).strip().lower()
-        if scenario in {"fire", "fall", "intrusion", "electrical"}:
-            return scenario
-
-        summary = event.summary.lower()
-        for hazard, keywords in self.HAZARD_KEYWORDS.items():
-            if any(keyword in summary for keyword in keywords):
-                return hazard
-        return "general"
-
-    def _build_rag_query(self, summary: str, hazard_hint: str) -> str:
-        if hazard_hint == "general":
-            return summary
-        hazard_label = {
-            "fire": "화재/연기",
-            "fall": "전도/낙상",
-            "intrusion": "무단 접근/위험 행동",
-            "electrical": "전기 설비 이상",
-        }.get(hazard_hint, "일반 위험")
-        return f"{hazard_label} 대응 기준으로 검색: {summary}"
-
-    def _score_reference(self, title: str, content: str, tags: list[str], hazard_hint: str) -> int:
-        if hazard_hint == "general":
-            return 0
-        joined = " ".join([title, content, " ".join(tags)]).lower()
-        keywords = self.HAZARD_KEYWORDS.get(hazard_hint, ())
-        return sum(1 for keyword in keywords if keyword in joined)
-
-    def _rerank_references(self, refs: list, hazard_hint: str) -> list:
-        if not refs or hazard_hint == "general":
-            return refs
-
-        positives: list[tuple[int, object]] = []
-        generals: list[object] = []
-        for ref in refs:
-            score = self._score_reference(ref.title, ref.content, ref.tags, hazard_hint)
-            if score > 0:
-                positives.append((score, ref))
-            elif ref.id.startswith("general") or "공통" in ref.title:
-                generals.append(ref)
-
-        if not positives:
-            return refs
-
-        positives.sort(key=lambda item: item[0], reverse=True)
-        ranked = [ref for _, ref in positives]
-        if generals:
-            ranked.append(generals[0])
-
-        top_k = getattr(self.local_retriever, "top_k", 3)
-        return ranked[:top_k]
-
-    async def process(self, event: DangerEvent) -> DangerResponse:
-        hazard_hint = self._infer_hazard_hint(event)
-        rag_query = self._build_rag_query(event.summary, hazard_hint)
-
+    async def _retrieve_references(
+        self,
+        rag_query: str,
+        hazard_hint: HazardHint,
+    ) -> tuple[list[RAGReference], str]:
         try:
-            refs = await asyncio.wait_for(
+            references = await asyncio.wait_for(
                 self.mcp_retriever.retrieve(rag_query),
                 timeout=self.mcp_timeout_sec,
             )
         except Exception:
-            refs = []
-        refs = self._rerank_references(refs, hazard_hint)
+            references = []
+
+        top_k = int(getattr(self.local_retriever, "top_k", 3))
+        references = self.hazard_context.rerank_references(
+            references=references,
+            hazard_hint=hazard_hint,
+            top_k=top_k,
+        )
+
         rag_source = "mcp"
-        if not refs:
-            refs = self.local_retriever.retrieve(rag_query)
-            refs = self._rerank_references(refs, hazard_hint)
-            rag_source = "local-fallback"
+        if references:
+            return references, rag_source
+
+        references = self.local_retriever.retrieve(rag_query)
+        references = self.hazard_context.rerank_references(
+            references=references,
+            hazard_hint=hazard_hint,
+            top_k=top_k,
+        )
+        return references, "local-fallback"
+
+    async def process(self, event: DangerEvent) -> DangerResponse:
+        hazard_hint = self.hazard_context.infer_hazard_hint(event)
+        rag_query = self.hazard_context.build_rag_query(event.summary, hazard_hint)
+        refs, rag_source = await self._retrieve_references(rag_query, hazard_hint)
 
         operator_response, jetson_summary = await self.responder.build_response(
             situation=event.summary,

--- a/tests/test_hazard_context.py
+++ b/tests/test_hazard_context.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timezone
+
+from src.api.models import DangerEvent, RAGReference
+from src.api.services.hazard_context import HazardContextService
+
+
+def _event(summary: str, metadata: dict | None = None) -> DangerEvent:
+    return DangerEvent(
+        event_id="evt_test",
+        timestamp=datetime.now(timezone.utc),
+        source="test",
+        summary=summary,
+        metadata=metadata,
+    )
+
+
+def test_infer_hazard_hint_from_metadata_scenario() -> None:
+    service = HazardContextService()
+    event = _event("일반 상황", metadata={"scenario": "fire"})
+    assert service.infer_hazard_hint(event) == "fire"
+
+
+def test_infer_hazard_hint_from_summary_keyword() -> None:
+    service = HazardContextService()
+    event = _event("바닥이 젖어 있어 넘어질 위험이 높습니다")
+    assert service.infer_hazard_hint(event) == "fall"
+
+
+def test_build_rag_query_includes_hazard_label() -> None:
+    service = HazardContextService()
+    assert (
+        service.build_rag_query("연기가 발생했습니다", "fire")
+        == "화재/연기 대응 기준으로 검색: 연기가 발생했습니다"
+    )
+    assert service.build_rag_query("원인 불명 위험", "general") == "원인 불명 위험"
+
+
+def test_rerank_references_prioritizes_hazard_and_common() -> None:
+    service = HazardContextService()
+    refs = [
+        RAGReference(id="fire-1", title="화재 대응", content="화재 시 대피", tags=["화재"]),
+        RAGReference(id="fall-1", title="전도 위험 대응", content="미끄럼과 낙상 예방", tags=["낙상"]),
+        RAGReference(
+            id="general-1",
+            title="일반 위험 대응 공통 절차",
+            content="공통 절차",
+            tags=[],
+        ),
+    ]
+    ranked = service.rerank_references(refs, "fall", top_k=2)
+    assert [ref.id for ref in ranked] == ["fall-1", "general-1"]
+
+
+def test_rerank_references_keeps_order_when_no_positive_match() -> None:
+    service = HazardContextService()
+    refs = [
+        RAGReference(id="intrusion-1", title="출입 통제", content="무단 접근 대응", tags=["보안"]),
+        RAGReference(id="general-1", title="일반 위험 대응 공통 절차", content="공통 절차", tags=[]),
+    ]
+    ranked = service.rerank_references(refs, "electrical", top_k=3)
+    assert [ref.id for ref in ranked] == ["intrusion-1", "general-1"]


### PR DESCRIPTION
## ✨ 설명
`DangerProcessingPipeline` 내부 hazard 규칙을 별도 서비스로 분리해 파이프라인 책임을 단순화하고 타입 안정성을 강화했습니다.

## ✅ 작업 상세 내용
- `src/api/services/hazard_context.py` 신규 추가
- hazard hint 추론 / RAG query 생성 / reference 재정렬 로직 분리
- `src/api/services/pipeline.py`를 오케스트레이션 중심으로 단순화
- `tests/test_hazard_context.py` 신규 추가

## 📚 기능의 필요성
규칙성 비즈니스 로직과 오케스트레이션이 한 파일에 혼재되어 있던 구조를 분리해 유지보수성과 테스트 용이성을 높이기 위함입니다.

## 🛠 구현 방법
HazardContextService를 도입해 기존 메서드를 서비스로 이동하고, Pipeline에서는 주입된 서비스 호출만 하도록 변경했습니다.

## 📌 기타사항
- `docs/2026-02-21-refactor-phase7.md`는 기록용으로 커밋 제외
- 테스트는 pytest 미설치 환경으로 수동 실행 검증(`manual-tests: ok`)

Closes #32