### PR TITLE
[ENHANCEMENT] API 설정 로딩을 pydantic-settings로 전환 (8차)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ requests>=2.31.0
 opencv-python>=4.9.0.80
 numpy>=1.26.0
 pydantic>=2.6.0
+pydantic-settings>=2.2.1
 httpx>=0.27.0
 langchain>=0.3.0
 langchain-mcp-adapters>=0.1.0

--- a/tests/test_api_config_settings.py
+++ b/tests/test_api_config_settings.py
@@ -1,0 +1,51 @@
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+from src.api.config import ApiConfig
+
+
+@contextmanager
+def _temporary_env(values: dict[str, str]) -> Iterator[None]:
+    previous: dict[str, str | None] = {key: os.environ.get(key) for key in values}
+    try:
+        for key, value in values.items():
+            os.environ[key] = value
+        yield
+    finally:
+        for key, original in previous.items():
+            if original is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = original
+
+
+def test_settings_env_parsing_and_url_hydration() -> None:
+    env_values = {
+        "RAG_MCP_TRANSPORT": "streamable_http",
+        "RAG_MCP_HOST": "10.0.0.10",
+        "RAG_MCP_PORT": "9000",
+        "RAG_MCP_PATH": "mcp",
+        "RAG_MCP_ARGS": "-m src.mcp.rag_server",
+        "OPS_MCP_TRANSPORT": "streamable_http",
+        "OPS_MCP_HOST": "10.0.0.11",
+        "OPS_MCP_PORT": "9001",
+        "OPS_MCP_PATH": "/ops-mcp",
+        "OPS_MCP_ARGS": "-m src.mcp.ops_server",
+        "RAG_MCP_ENABLED": "false",
+        "GEMINI_TTS_STYLE_PROMPT": "   ",
+    }
+    with _temporary_env(env_values):
+        config = ApiConfig(_env_file=None)
+
+    assert config.rag_mcp_enabled is False
+    assert config.rag_mcp_args == ["-m", "src.mcp.rag_server"]
+    assert config.ops_mcp_args == ["-m", "src.mcp.ops_server"]
+    assert config.rag_mcp_url == "http://10.0.0.10:9000/mcp"
+    assert config.ops_mcp_url == "http://10.0.0.11:9001/ops-mcp"
+    assert config.gemini_tts_style_prompt is None
+
+
+def test_from_env_compatibility_method() -> None:
+    config = ApiConfig.from_env()
+    assert isinstance(config, ApiConfig)


### PR DESCRIPTION
## ✨ 설명
API 설정 로딩 계층을 `pydantic-settings` 기반으로 전환해 env 파싱/검증 안정성을 강화했습니다.

## ✅ 작업 상세 내용
- `src/api/config.py`를 `BaseSettings` 기반으로 전환
- 기존 env 키(`API_*`, `RAG_MCP_*`, `OPS_MCP_*`, `GEMINI_*`) 호환 유지
- `RAG_MCP_ARGS`, `OPS_MCP_ARGS` 문자열 파싱 validator 추가
- `RAG_MCP_URL`, `OPS_MCP_URL` 자동 구성 model validator 추가
- `tests/test_api_config_settings.py` 신규 추가
- `requirements.txt`에 `pydantic-settings` 추가

## 📚 기능의 필요성
수동 파싱 로직 제거로 설정 필드 확장 시 누락 리스크를 줄이고, 타입 검증 일관성을 확보하기 위함입니다.

## 🛠 구현 방법
`ApiConfig`를 `BaseSettings`로 전환하고, `validation_alias`로 기존 환경변수명을 매핑했습니다. 기존 진입점 호환을 위해 `from_env()` 메서드는 유지했습니다.

## 📌 기타사항
- README 수정 없음
- `docs/2026-02-21-refactor-phase8.md`는 기록용으로 커밋 제외
- 테스트는 pytest 미설치 환경이라 수동 실행으로 검증(`manual-tests: ok`)

Closes #34