### PR TITLE
[FIX] Edge VLM 오탐(항상 DANGER) 완화 및 판정 계측 추가

### DIFF
--- a/src/edge/config.py
+++ b/src/edge/config.py
@@ -16,6 +16,9 @@ class EdgeConfig:
     vlm_timeout_sec: int = 20
     vlm_keep_alive: str = "10m"
     vlm_use_heuristic_fallback: bool = True
+    vlm_min_danger_score: float = 0.7
+    vlm_uncertain_as_safe: bool = True
+    vlm_danger_double_check: bool = True
     vlm_raw_log_enabled: bool = True
     vlm_raw_log_path: str = "data/edge/vlm_raw_responses.jsonl"
     request_timeout_sec: int = 5
@@ -63,6 +66,9 @@ class EdgeConfig:
             vlm_timeout_sec=int(os.getenv("EDGE_VLM_TIMEOUT_SEC", "20")),
             vlm_keep_alive=os.getenv("EDGE_VLM_KEEP_ALIVE", "10m").strip(),
             vlm_use_heuristic_fallback=os.getenv("EDGE_VLM_HEURISTIC_FALLBACK", "true").lower() == "true",
+            vlm_min_danger_score=float(os.getenv("EDGE_VLM_MIN_DANGER_SCORE", "0.7")),
+            vlm_uncertain_as_safe=os.getenv("EDGE_VLM_UNCERTAIN_AS_SAFE", "true").lower() == "true",
+            vlm_danger_double_check=os.getenv("EDGE_VLM_DANGER_DOUBLE_CHECK", "true").lower() == "true",
             vlm_raw_log_enabled=os.getenv("EDGE_VLM_RAW_LOG_ENABLED", "true").lower() == "true",
             vlm_raw_log_path=os.getenv("EDGE_VLM_RAW_LOG_PATH", "data/edge/vlm_raw_responses.jsonl").strip(),
             request_timeout_sec=int(os.getenv("EDGE_REQUEST_TIMEOUT_SEC", "5")),

--- a/src/edge/orchestrator.py
+++ b/src/edge/orchestrator.py
@@ -98,6 +98,9 @@ class EdgeOrchestrator:
             timeout_sec=cfg.vlm_timeout_sec,
             keep_alive=cfg.vlm_keep_alive,
             use_heuristic_fallback=cfg.vlm_use_heuristic_fallback,
+            min_danger_score=cfg.vlm_min_danger_score,
+            uncertain_as_safe=cfg.vlm_uncertain_as_safe,
+            danger_double_check=cfg.vlm_danger_double_check,
             raw_log_enabled=cfg.vlm_raw_log_enabled,
             raw_log_path=cfg.vlm_raw_log_path,
         )

--- a/src/edge/vlm_client.py
+++ b/src/edge/vlm_client.py
@@ -19,6 +19,9 @@ class VLMClient:
         timeout_sec: int = 20,
         keep_alive: str = "10m",
         use_heuristic_fallback: bool = True,
+        min_danger_score: float = 0.7,
+        uncertain_as_safe: bool = True,
+        danger_double_check: bool = True,
         raw_log_enabled: bool = True,
         raw_log_path: str = "data/edge/vlm_raw_responses.jsonl",
     ) -> None:
@@ -28,6 +31,9 @@ class VLMClient:
         self.timeout_sec = timeout_sec
         self.keep_alive = keep_alive
         self.use_heuristic_fallback = use_heuristic_fallback
+        self.min_danger_score = max(0.0, min(1.0, float(min_danger_score)))
+        self.uncertain_as_safe = uncertain_as_safe
+        self.danger_double_check = danger_double_check
         self.raw_log_enabled = raw_log_enabled
         self.raw_log_path = Path(raw_log_path)
         self.logger = logging.getLogger(__name__)
@@ -72,20 +78,69 @@ class VLMClient:
 
     def _analyze_with_ollama(self, frame: np.ndarray) -> tuple[bool, str, float, dict[str, Any]]:
         encoded_image = self._encode_frame_to_base64(frame)
+
         classify_raw, classify_meta = self._call_ollama(
             prompt=(
-                "당신은 산업안전 감시 분류기다. "
-                "출력은 정확히 한 단어만: DANGER 또는 SAFE. "
-                "설명, 문장, 구두점, 추가 텍스트 금지."
+                "당신은 산업안전 이진 분류기다.\n"
+                "아래 JSON 객체 하나만 출력하라. 다른 문장/설명/코드블록 금지.\n"
+                "{\"label\":\"DANGER|SAFE\",\"risk_score\":0.0,\"hazard_type\":\"fire|fall|intrusion|electrical|unknown\",\"evidence\":[\"근거1\",\"근거2\"]}\n"
+                "규칙: 위험 근거가 불충분하거나 애매하면 label=SAFE, risk_score<=0.49.\n"
+                "risk_score는 0~1 사이 숫자."
             ),
             image_base64=encoded_image,
         )
-        label = self._normalize_label(classify_raw)
-        if label is None:
-            raise RuntimeError(f"Unexpected classification response: {classify_raw!r}")
 
-        is_danger = label == "DANGER"
-        confidence = 0.93 if is_danger else 0.88
+        parsed = self._parse_classification(classify_raw)
+        parse_status = "json-parsed" if parsed is not None else "parse-failed"
+        if parsed is None:
+            if self.uncertain_as_safe:
+                parsed = {
+                    "label": "SAFE",
+                    "risk_score": 0.0,
+                    "hazard_type": "unknown",
+                    "evidence": [],
+                }
+                parse_status = "parse-failed-safe-default"
+            else:
+                raise RuntimeError(f"Unexpected classification response: {classify_raw!r}")
+
+        label = parsed["label"]
+        risk_score = parsed["risk_score"]
+        hazard_type = parsed["hazard_type"]
+        evidence = parsed["evidence"]
+
+        decision_notes: list[str] = []
+        final_label = label
+
+        if final_label == "DANGER" and risk_score < self.min_danger_score:
+            final_label = "SAFE"
+            decision_notes.append(
+                f"downgraded_by_min_danger_score({risk_score:.2f}<{self.min_danger_score:.2f})"
+            )
+
+        verify_raw = ""
+        verify_meta: dict[str, Any] = {}
+        verify_label: str | None = None
+        if final_label == "DANGER" and self.danger_double_check:
+            verify_raw, verify_meta = self._call_ollama(
+                prompt=(
+                    "재검증 단계다. 즉시 대피/통제가 필요한 명백한 위험이면 DANGER, 아니면 SAFE. "
+                    "애매하면 SAFE. 출력은 한 단어만: DANGER 또는 SAFE."
+                ),
+                image_base64=encoded_image,
+            )
+            verify_label = self._normalize_label(verify_raw)
+            if verify_label != "DANGER":
+                final_label = "SAFE"
+                decision_notes.append("downgraded_by_double_check")
+
+        is_danger = final_label == "DANGER"
+        confidence = self._derive_confidence(
+            final_label=final_label,
+            risk_score=risk_score,
+            verify_label=verify_label,
+        )
+
         summary = "특이 위험 상황은 감지되지 않았습니다."
         summary_source = "safe-default"
         summary_raw = ""
@@ -108,8 +163,18 @@ class VLMClient:
         meta = {
             "provider": "ollama",
             "model": self.model,
-            "classification": label,
-            "classification_raw": (classify_raw or "").strip()[:80],
+            "classification": final_label,
+            "classification_raw": (classify_raw or "").strip()[:200],
+            "classification_parse_status": parse_status,
+            "label_before_guardrail": label,
+            "risk_score": risk_score,
+            "min_danger_score": self.min_danger_score,
+            "hazard_type": hazard_type,
+            "evidence": evidence,
+            "danger_double_check": self.danger_double_check,
+            "double_check_raw": (verify_raw or "").strip()[:80],
+            "double_check_label": verify_label,
+            "decision_notes": decision_notes,
             "summary_source": summary_source,
             "request_prompt_eval_count": classify_meta.get("prompt_eval_count"),
             "request_eval_count": classify_meta.get("eval_count"),
@@ -121,14 +186,19 @@ class VLMClient:
                 "status": "ok",
                 "provider": "ollama",
                 "model": self.model,
-                "classification": label,
+                "classification_final": final_label,
+                "classification_input": parsed,
+                "classification_parse_status": parse_status,
                 "classification_raw": (classify_raw or "").strip(),
                 "classification_response": classify_meta,
+                "double_check_raw": (verify_raw or "").strip(),
+                "double_check_response": verify_meta,
                 "summary_raw": (summary_raw or "").strip(),
                 "summary_response": summary_meta,
                 "summary_used": summary,
                 "confidence": confidence,
                 "summary_source": summary_source,
+                "decision_notes": decision_notes,
             }
         )
         return is_danger, summary, confidence, meta
@@ -179,6 +249,89 @@ class VLMClient:
         if has_safe and not has_danger:
             return "SAFE"
         return None
+
+    def _parse_classification(self, raw_text: str) -> dict[str, Any] | None:
+        if not raw_text:
+            return None
+
+        text = raw_text.strip()
+        parsed_obj: dict[str, Any] | None = None
+
+        try:
+            loaded = json.loads(text)
+            if isinstance(loaded, dict):
+                parsed_obj = loaded
+        except Exception:
+            parsed_obj = None
+
+        if parsed_obj is None:
+            start = text.find("{")
+            end = text.rfind("}")
+            if start != -1 and end != -1 and end > start:
+                try:
+                    loaded = json.loads(text[start : end + 1])
+                    if isinstance(loaded, dict):
+                        parsed_obj = loaded
+                except Exception:
+                    parsed_obj = None
+
+        if parsed_obj is None:
+            label = self._normalize_label(text)
+            if label is None:
+                return None
+            return {
+                "label": label,
+                "risk_score": 0.55 if label == "DANGER" else 0.45,
+                "hazard_type": "unknown",
+                "evidence": [],
+            }
+
+        label = self._normalize_label(str(parsed_obj.get("label", "")))
+        if label is None:
+            return None
+
+        risk_score = self._coerce_score(parsed_obj.get("risk_score"))
+        if risk_score is None:
+            risk_score = 0.5 if label == "DANGER" else 0.2
+
+        hazard_type = str(parsed_obj.get("hazard_type", "unknown") or "unknown").strip().lower()
+        if not hazard_type:
+            hazard_type = "unknown"
+
+        evidence_raw = parsed_obj.get("evidence", [])
+        evidence: list[str] = []
+        if isinstance(evidence_raw, list):
+            evidence = [str(item).strip() for item in evidence_raw if str(item).strip()]
+
+        return {
+            "label": label,
+            "risk_score": risk_score,
+            "hazard_type": hazard_type,
+            "evidence": evidence[:3],
+        }
+
+    @staticmethod
+    def _coerce_score(value: Any) -> float | None:
+        try:
+            score = float(value)
+        except Exception:
+            return None
+        if score < 0:
+            score = 0.0
+        if score > 1:
+            score = 1.0
+        return score
+
+    @staticmethod
+    def _derive_confidence(final_label: str, risk_score: float, verify_label: str | None) -> float:
+        if final_label == "DANGER":
+            base = max(0.7, min(0.99, risk_score))
+            if verify_label == "DANGER":
+                base = min(0.99, base + 0.04)
+            return round(base, 3)
+
+        safe_conf = max(0.51, 1.0 - risk_score)
+        return round(min(0.95, safe_conf), 3)
 
     @staticmethod
     def _sanitize_summary(raw_text: str) -> str:

--- a/src/sim/eval_vlm_dataset.py
+++ b/src/sim/eval_vlm_dataset.py
@@ -1,0 +1,131 @@
+import argparse
+import json
+import random
+import time
+from pathlib import Path
+
+import cv2
+
+from src.edge.config import EdgeConfig
+from src.edge.vlm_client import VLMClient
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate edge VLM on image folders (safe/danger).")
+    parser.add_argument("--safe-dir", default="data/eval/safe", help="Folder with SAFE images")
+    parser.add_argument("--danger-dir", default="data/eval/danger", help="Folder with DANGER images")
+    parser.add_argument("--limit", type=int, default=0, help="Max images per class (0=all)")
+    parser.add_argument("--shuffle", action="store_true", help="Shuffle evaluation order")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed when shuffle enabled")
+    parser.add_argument("--save-json", default="", help="Optional output json file path")
+    return parser.parse_args()
+
+
+def collect_images(folder: Path, limit: int) -> list[Path]:
+    if not folder.exists():
+        return []
+    exts = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+    files = [p for p in sorted(folder.rglob("*")) if p.is_file() and p.suffix.lower() in exts]
+    if limit > 0:
+        return files[:limit]
+    return files
+
+
+def main() -> None:
+    args = parse_args()
+    safe_dir = Path(args.safe_dir)
+    danger_dir = Path(args.danger_dir)
+
+    safe_images = collect_images(safe_dir, args.limit)
+    danger_images = collect_images(danger_dir, args.limit)
+
+    if not safe_images and not danger_images:
+        raise SystemExit("No images found. Put images in --safe-dir and/or --danger-dir first.")
+
+    samples: list[tuple[Path, bool]] = [(p, False) for p in safe_images] + [(p, True) for p in danger_images]
+    if args.shuffle:
+        random.seed(args.seed)
+        random.shuffle(samples)
+
+    cfg = EdgeConfig.from_env()
+    vlm = VLMClient(
+        provider=cfg.vlm_provider,
+        model=cfg.vlm_model,
+        ollama_url=cfg.vlm_ollama_url,
+        timeout_sec=cfg.vlm_timeout_sec,
+        keep_alive=cfg.vlm_keep_alive,
+        use_heuristic_fallback=cfg.vlm_use_heuristic_fallback,
+        min_danger_score=cfg.vlm_min_danger_score,
+        uncertain_as_safe=cfg.vlm_uncertain_as_safe,
+        danger_double_check=cfg.vlm_danger_double_check,
+        raw_log_enabled=cfg.vlm_raw_log_enabled,
+        raw_log_path=cfg.vlm_raw_log_path,
+    )
+
+    tp = tn = fp = fn = 0
+    latencies_ms: list[float] = []
+    failures: list[dict[str, str]] = []
+
+    for image_path, expected_danger in samples:
+        frame = cv2.imread(str(image_path))
+        if frame is None:
+            failures.append({"image": str(image_path), "reason": "imread_failed"})
+            continue
+
+        start = time.perf_counter()
+        pred_is_danger, _, confidence, meta = vlm.analyze_frame(frame)
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        latencies_ms.append(elapsed_ms)
+
+        if expected_danger and pred_is_danger:
+            tp += 1
+        elif expected_danger and not pred_is_danger:
+            fn += 1
+        elif (not expected_danger) and pred_is_danger:
+            fp += 1
+        else:
+            tn += 1
+
+        print(
+            f"[{image_path.name}] expected={'DANGER' if expected_danger else 'SAFE'} "
+            f"pred={'DANGER' if pred_is_danger else 'SAFE'} conf={confidence:.3f} "
+            f"latency_ms={elapsed_ms:.1f} provider={meta.get('provider')}"
+        )
+
+    total = tp + tn + fp + fn
+    fp_rate = (fp / (fp + tn) * 100.0) if (fp + tn) else 0.0
+    tp_rate = (tp / (tp + fn) * 100.0) if (tp + fn) else 0.0
+    avg_latency = (sum(latencies_ms) / len(latencies_ms)) if latencies_ms else 0.0
+
+    summary = {
+        "total": total,
+        "safe_count": tn + fp,
+        "danger_count": tp + fn,
+        "tp": tp,
+        "tn": tn,
+        "fp": fp,
+        "fn": fn,
+        "fp_rate_percent": round(fp_rate, 2),
+        "tp_rate_percent": round(tp_rate, 2),
+        "avg_latency_ms": round(avg_latency, 1),
+        "min_latency_ms": round(min(latencies_ms), 1) if latencies_ms else 0.0,
+        "max_latency_ms": round(max(latencies_ms), 1) if latencies_ms else 0.0,
+        "failed_images": failures,
+    }
+
+    print("\n=== SUMMARY ===")
+    for k, v in summary.items():
+        if k == "failed_images":
+            print(f"{k}: {len(v)}")
+        else:
+            print(f"{k}: {v}")
+
+    if args.save_json:
+        output = Path(args.save_json)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"Saved summary JSON: {output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
✨ 설명
Jetson 로컬 VLM 오탐 문제 완화를 위해 분류 가드레일과 평가 도구를 추가했습니다.

✅ 작업 상세 내용(체크리스트)
- [x] JSON 기반 분류 프롬프트/파싱 강화
- [x] 최소 위험 점수/재검증 가드레일 추가
- [x] 불확실 응답 SAFE 처리 옵션 추가
- [x] 로컬 이미지셋 평가 스크립트 추가
- [x] 오탐/정탐/지연시간 계측 가능화

📚 기능의 필요성
항상 DANGER로 분류되는 경향으로 운영 신뢰도가 낮아, 1차 목표(오탐률 ≤ 5%) 달성을 위한 기반이 필요합니다.

🛠 예상 구현 방법
Edge VLM에서 이진 판정 신뢰도 가드레일을 적용하고, Jetson에서 반복 측정 가능한 평가 루틴을 제공합니다.

📌 기타사항
- README.md 미수정
- docs 작업 로그 파일은 커밋 제외