### PR TITLE
[FIX] 로컬 알림 UX 고정: 사이렌 최소 10초 후 WAV 재생

### DIFF
--- a/src/edge/alerts.py
+++ b/src/edge/alerts.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 
 from src.edge.alerts_indicator import IndicatorOutput
 from src.edge.alerts_speech import SpeechOutput
@@ -53,6 +54,16 @@ class AlertController:
 
     def trigger_danger(self, duration_sec: int = 3) -> None:
         self.indicator.trigger_danger(duration_sec=duration_sec)
+
+    def trigger_danger_async(self, duration_sec: int = 3) -> threading.Thread:
+        worker = threading.Thread(
+            target=self.trigger_danger,
+            kwargs={"duration_sec": duration_sec},
+            daemon=True,
+            name="edge-danger-alert",
+        )
+        worker.start()
+        return worker
 
     def speak(self, text: str) -> None:
         self.speech.speak(text)

--- a/src/edge/config.py
+++ b/src/edge/config.py
@@ -24,6 +24,7 @@ class EdgeConfig:
     request_timeout_sec: int = 5
     request_retries: int = 2
     alert_duration_sec: int = 3
+    min_siren_duration_sec: int = 10
     led_gpio_pin: int = 17
     danger_led_pins: list[int] | None = None
     safe_led_pins: list[int] | None = None
@@ -74,6 +75,7 @@ class EdgeConfig:
             request_timeout_sec=int(os.getenv("EDGE_REQUEST_TIMEOUT_SEC", "5")),
             request_retries=int(os.getenv("EDGE_REQUEST_RETRIES", "2")),
             alert_duration_sec=int(os.getenv("EDGE_ALERT_DURATION_SEC", "3")),
+            min_siren_duration_sec=int(os.getenv("EDGE_MIN_SIREN_DURATION_SEC", "10")),
             led_gpio_pin=int(os.getenv("EDGE_LED_GPIO_PIN", "17")),
             danger_led_pins=parsed_led_pins,
             safe_led_pins=parsed_safe_led_pins,

--- a/src/edge/orchestrator.py
+++ b/src/edge/orchestrator.py
@@ -178,8 +178,16 @@ class EdgeOrchestrator:
                     infer_meta=infer_meta,
                 )
 
-                self.alerts.trigger_danger(duration_sec=self.cfg.alert_duration_sec)
+                danger_alert_sec = max(self.cfg.alert_duration_sec, self.cfg.min_siren_duration_sec)
+                self.logger.info(
+                    "Danger workflow started: event_id=%s min_siren_sec=%s",
+                    event_id,
+                    danger_alert_sec,
+                )
+                alert_thread = self.alerts.trigger_danger_async(duration_sec=danger_alert_sec)
                 ack = self.client.send(payload)
+                alert_thread.join()
+
                 if ack is None:
                     self.logger.error("Server send failed. event_id=%s payload=%s", event_id, payload)
                     if self.cfg.server_wav_only:


### PR DESCRIPTION
## 작업 내용
- Edge 설정에 `EDGE_MIN_SIREN_DURATION_SEC`(기본 10초) 추가
- `AlertController.trigger_danger_async()` 추가 (즉시 경보 시작)
- Orchestrator 흐름을 `경보 시작 -> 서버 전송 -> 경보 종료 대기 -> WAV/TTS 재생` 순서로 고정

## 검증
- `python3 -m compileall src/edge`
- `EdgeConfig.from_env()`에서 `min_siren_duration_sec` 로드 확인

## 비고
- `docs/2026-02-22-alert-ux-10s-siren.md`는 기록용으로 커밋 제외
